### PR TITLE
remove the dependency on byteorder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 [dependencies]
 arrayref = "0.3.5"
 arrayvec = { version = "0.4.7", default-features = false, features = ["use_union"] }
-byteorder = { version = "1.2.4", default-features = false }
 constant_time_eq = "0.1.3"
 rayon = { version = "1.0.2", optional = true }
 

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -1,5 +1,3 @@
-use byteorder::{ByteOrder, LittleEndian};
-
 use Block;
 use StateWords;
 use IV;
@@ -81,8 +79,25 @@ pub fn compress(h: &mut StateWords, msg: &Block, count: u128, lastblock: u64, la
     ];
 
     // Parse the message bytes as ints in little endian order.
-    let mut m = [0; 16];
-    LittleEndian::read_u64_into(msg, &mut m);
+    let msg_refs = array_refs!(msg, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8);
+    let m = [
+        u64::from_le_bytes(*msg_refs.0),
+        u64::from_le_bytes(*msg_refs.1),
+        u64::from_le_bytes(*msg_refs.2),
+        u64::from_le_bytes(*msg_refs.3),
+        u64::from_le_bytes(*msg_refs.4),
+        u64::from_le_bytes(*msg_refs.5),
+        u64::from_le_bytes(*msg_refs.6),
+        u64::from_le_bytes(*msg_refs.7),
+        u64::from_le_bytes(*msg_refs.8),
+        u64::from_le_bytes(*msg_refs.9),
+        u64::from_le_bytes(*msg_refs.10),
+        u64::from_le_bytes(*msg_refs.11),
+        u64::from_le_bytes(*msg_refs.12),
+        u64::from_le_bytes(*msg_refs.13),
+        u64::from_le_bytes(*msg_refs.14),
+        u64::from_le_bytes(*msg_refs.15),
+    ];
 
     round(0, &m, &mut v);
     round(1, &m, &mut v);


### PR DESCRIPTION
Since that crate takes slices in its API, it tends to introduce unnecessary bounds checks.